### PR TITLE
`charSet` fix

### DIFF
--- a/gatsby-ssr.js
+++ b/gatsby-ssr.js
@@ -14,6 +14,6 @@ exports.onRenderBody = function (_ref, pluginOptions) {
     key: "gatsby-plugin-tawk",
     async: true,
     src: "https://embed.tawk.to/" + tawkId + "/default",
-    charset: 'UTF-8'
+    charSet: 'UTF-8'
   })]);
 };


### PR DESCRIPTION
Fixes the warning : 


```
Warning: Invalid DOM property `charset`. Did you mean `charSet`?
    in script
    in body
    in html
    in HTML
```